### PR TITLE
Add chat session REST endpoints

### DIFF
--- a/app/api/v1/chat.py
+++ b/app/api/v1/chat.py
@@ -1,0 +1,86 @@
+"""Chat session REST endpoints (spec §6.4, issue #16)."""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user, get_db
+from app.api.schemas.chat import MessageOut, SessionCreate, SessionDetail, SessionSummary
+from app.core.ws_manager import manager
+from app.db.models import ChatMessage, ChatSession, User
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+_SESSION_NOT_FOUND = "Session not found"
+_WS_SESSION_DELETED = 4010
+
+
+@router.post("/sessions", response_model=SessionSummary, status_code=status.HTTP_201_CREATED)
+def create_session(
+    payload: SessionCreate,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> ChatSession:
+    session = ChatSession(user_id=user.id, title=payload.title)
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+    return session
+
+
+@router.get("/sessions", response_model=list[SessionSummary])
+def list_sessions(
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[ChatSession]:
+    return (
+        db.query(ChatSession)
+        .filter(ChatSession.user_id == user.id)
+        .order_by(ChatSession.updated_at.desc())
+        .all()
+    )
+
+
+@router.get("/sessions/{session_id}", response_model=SessionDetail)
+def get_session(
+    session_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> SessionDetail:
+    session = db.get(ChatSession, session_id)
+    if session is None or session.user_id != user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_SESSION_NOT_FOUND)
+
+    messages = (
+        db.query(ChatMessage)
+        .filter(ChatMessage.session_id == session_id)
+        .order_by(ChatMessage.position)
+        .limit(200)
+        .all()
+    )
+
+    return SessionDetail(
+        id=session.id,
+        title=session.title,
+        created_at=session.created_at,
+        updated_at=session.updated_at,
+        messages=[MessageOut.model_validate(m) for m in messages],
+    )
+
+
+@router.delete("/sessions/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_session(
+    session_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> None:
+    session = db.get(ChatSession, session_id)
+    if session is None or session.user_id != user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_SESSION_NOT_FOUND)
+
+    await manager.close_session(user.id, session_id, _WS_SESSION_DELETED)
+
+    db.delete(session)
+    db.commit()

--- a/app/core/ws_manager.py
+++ b/app/core/ws_manager.py
@@ -96,5 +96,24 @@ class ConnectionManager:
         async with self._lock:
             return bool(self.active_connections.get(user_id))
 
+    async def close_session(self, user_id: int, session_id: int, code: int) -> None:
+        """Close a session's WebSocket with the given close code and remove it."""
+        async with self._lock:
+            user_sessions = self.active_connections.get(user_id, {})
+            ws = user_sessions.pop(session_id, None)
+            if not user_sessions:
+                self.active_connections.pop(user_id, None)
+        if ws is not None:
+            try:
+                await ws.close(code=code)
+            except Exception as exc:
+                logger.debug(
+                    "close_session(user=%s, session=%s, code=%s) failed: %s",
+                    user_id,
+                    session_id,
+                    code,
+                    exc,
+                )
+
 
 manager = ConnectionManager()

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api.v1 import auth, deploy, monitor
+from app.api.v1 import auth, chat, deploy, monitor
 from app.core.logging_config import configure_logging
 from app.db.base import Base
 from app.db.session import engine
@@ -45,12 +45,12 @@ app.add_middleware(
 )
 
 app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
+app.include_router(chat.router, prefix="/api/v1/chat", tags=["chat"])
 app.include_router(deploy.router, prefix="/api/v1/deploy", tags=["deploy"])
 app.include_router(monitor.router, prefix="/api/v1/monitor", tags=["monitor"])
 
 # TODO(#18): wire remaining routers once they exist
-# from app.api.v1 import chat, visualize
-# app.include_router(chat.router,       prefix="/api/v1/chat",       tags=["chat"])
+# from app.api.v1 import visualize
 # app.include_router(visualize.router,  prefix="/api/v1/visualize",  tags=["visualize"])
 
 

--- a/tests/test_chat_rest.py
+++ b/tests/test_chat_rest.py
@@ -1,0 +1,296 @@
+"""Tests for the chat session REST endpoints (issue #16)."""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.security import hash_password
+from app.db.models import ChatMessage, ChatSession, User
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_session(db_session: Session, user_id: int, **fields: Any) -> ChatSession:
+    session = ChatSession(
+        user_id=user_id,
+        title=fields.get("title", "Test Session"),
+    )
+    if "updated_at" in fields:
+        session.updated_at = fields["updated_at"]
+    db_session.add(session)
+    db_session.commit()
+    db_session.refresh(session)
+    return session
+
+
+def _seed_message(
+    db_session: Session,
+    session_id: int,
+    position: int,
+    role: str = "user",
+    content: str = "hello",
+) -> ChatMessage:
+    msg = ChatMessage(
+        session_id=session_id,
+        role=role,
+        content=content,
+        position=position,
+    )
+    db_session.add(msg)
+    db_session.commit()
+    db_session.refresh(msg)
+    return msg
+
+
+def _seed_other_user(db_session: Session) -> User:
+    other = User(
+        email="other@example.com",
+        hashed_password=hash_password("pw"),
+        namespace="user-other",
+    )
+    db_session.add(other)
+    db_session.commit()
+    db_session.refresh(other)
+    return other
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/chat/sessions
+# ---------------------------------------------------------------------------
+
+
+def test_create_session_default_title(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    resp = client.post("/api/v1/chat/sessions", json={}, headers=auth_headers)
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["title"] == "New Chat"
+    assert "id" in body
+    assert "created_at" in body
+    assert "updated_at" in body
+
+
+def test_create_session_custom_title(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    resp = client.post(
+        "/api/v1/chat/sessions", json={"title": "My Session"}, headers=auth_headers
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["title"] == "My Session"
+
+
+def test_create_session_requires_auth(client: TestClient) -> None:
+    resp = client.post("/api/v1/chat/sessions", json={})
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/chat/sessions
+# ---------------------------------------------------------------------------
+
+
+def test_list_sessions_empty(client: TestClient, auth_headers: dict[str, str]) -> None:
+    resp = client.get("/api/v1/chat/sessions", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_list_sessions_sorted_by_recency(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    now = datetime.now(timezone.utc)
+    older = _seed_session(db_session, user.id, title="Older", updated_at=now - timedelta(hours=2))
+    newer = _seed_session(db_session, user.id, title="Newer", updated_at=now)
+
+    resp = client.get("/api/v1/chat/sessions", headers=auth_headers)
+    assert resp.status_code == 200
+    ids = [s["id"] for s in resp.json()]
+    assert ids == [newer.id, older.id]
+
+
+def test_list_sessions_excludes_other_users(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    other = _seed_other_user(db_session)
+
+    _seed_session(db_session, user.id, title="Mine")
+    _seed_session(db_session, other.id, title="Theirs")
+
+    resp = client.get("/api/v1/chat/sessions", headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["title"] == "Mine"
+
+
+def test_list_sessions_requires_auth(client: TestClient) -> None:
+    resp = client.get("/api/v1/chat/sessions")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/chat/sessions/{session_id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_session_with_messages(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    session = _seed_session(db_session, user.id, title="Detailed")
+    _seed_message(db_session, session.id, position=0, content="hello")
+    _seed_message(db_session, session.id, position=1, role="infra-agent", content="world")
+
+    resp = client.get(f"/api/v1/chat/sessions/{session.id}", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["id"] == session.id
+    assert body["title"] == "Detailed"
+    assert len(body["messages"]) == 2
+    assert body["messages"][0]["position"] == 0
+    assert body["messages"][1]["position"] == 1
+
+
+def test_get_session_no_messages(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    session = _seed_session(db_session, user.id)
+
+    resp = client.get(f"/api/v1/chat/sessions/{session.id}", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["messages"] == []
+
+
+def test_get_session_limits_to_200_messages(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    session = _seed_session(db_session, user.id)
+    for i in range(205):
+        _seed_message(db_session, session.id, position=i)
+
+    resp = client.get(f"/api/v1/chat/sessions/{session.id}", headers=auth_headers)
+    assert resp.status_code == 200
+    assert len(resp.json()["messages"]) == 200
+
+
+def test_get_session_unknown_returns_404(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    resp = client.get("/api/v1/chat/sessions/99999", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_get_session_other_user_returns_404(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+) -> None:
+    other = _seed_other_user(db_session)
+    session = _seed_session(db_session, other.id)
+
+    resp = client.get(f"/api/v1/chat/sessions/{session.id}", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_get_session_requires_auth(client: TestClient) -> None:
+    resp = client.get("/api/v1/chat/sessions/1")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/v1/chat/sessions/{session_id}
+# ---------------------------------------------------------------------------
+
+
+def test_delete_session_returns_204(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    session = _seed_session(db_session, user.id)
+
+    resp = client.delete(f"/api/v1/chat/sessions/{session.id}", headers=auth_headers)
+    assert resp.status_code == 204
+
+
+def test_delete_session_removes_from_db(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    session = _seed_session(db_session, user.id)
+    session_id = session.id
+
+    client.delete(f"/api/v1/chat/sessions/{session_id}", headers=auth_headers)
+
+    db_session.expire_all()
+    assert db_session.get(ChatSession, session_id) is None
+
+
+def test_delete_session_unknown_returns_404(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    resp = client.delete("/api/v1/chat/sessions/99999", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_delete_session_other_user_returns_404(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+) -> None:
+    other = _seed_other_user(db_session)
+    session = _seed_session(db_session, other.id)
+
+    resp = client.delete(f"/api/v1/chat/sessions/{session.id}", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_delete_session_requires_auth(client: TestClient) -> None:
+    resp = client.delete("/api/v1/chat/sessions/1")
+    assert resp.status_code == 401
+
+
+def test_delete_session_closes_active_websocket(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    session = _seed_session(db_session, user.id)
+
+    closed_with: dict[str, Any] = {}
+
+    async def fake_close_session(user_id: int, session_id: int, code: int) -> None:
+        closed_with.update({"user_id": user_id, "session_id": session_id, "code": code})
+
+    monkeypatch.setattr("app.api.v1.chat.manager.close_session", fake_close_session)
+
+    resp = client.delete(f"/api/v1/chat/sessions/{session.id}", headers=auth_headers)
+    assert resp.status_code == 204
+    assert closed_with == {"user_id": user.id, "session_id": session.id, "code": 4010}

--- a/tests/test_chat_rest.py
+++ b/tests/test_chat_rest.py
@@ -65,9 +65,7 @@ def _seed_other_user(db_session: Session) -> User:
 # ---------------------------------------------------------------------------
 
 
-def test_create_session_default_title(
-    client: TestClient, auth_headers: dict[str, str]
-) -> None:
+def test_create_session_default_title(client: TestClient, auth_headers: dict[str, str]) -> None:
     resp = client.post("/api/v1/chat/sessions", json={}, headers=auth_headers)
     assert resp.status_code == 201, resp.text
     body = resp.json()
@@ -77,12 +75,8 @@ def test_create_session_default_title(
     assert "updated_at" in body
 
 
-def test_create_session_custom_title(
-    client: TestClient, auth_headers: dict[str, str]
-) -> None:
-    resp = client.post(
-        "/api/v1/chat/sessions", json={"title": "My Session"}, headers=auth_headers
-    )
+def test_create_session_custom_title(client: TestClient, auth_headers: dict[str, str]) -> None:
+    resp = client.post("/api/v1/chat/sessions", json={"title": "My Session"}, headers=auth_headers)
     assert resp.status_code == 201, resp.text
     assert resp.json()["title"] == "My Session"
 
@@ -195,9 +189,7 @@ def test_get_session_limits_to_200_messages(
     assert len(resp.json()["messages"]) == 200
 
 
-def test_get_session_unknown_returns_404(
-    client: TestClient, auth_headers: dict[str, str]
-) -> None:
+def test_get_session_unknown_returns_404(client: TestClient, auth_headers: dict[str, str]) -> None:
     resp = client.get("/api/v1/chat/sessions/99999", headers=auth_headers)
     assert resp.status_code == 404
 


### PR DESCRIPTION
Implements the four chat session REST endpoints from issue #16.

POST /api/v1/chat/sessions - creates a session with an optional title, returns 201

GET /api/v1/chat/sessions - lists the authenticated user's sessions sorted by updated_at descending

GET /api/v1/chat/sessions/{session_id} - returns session detail with up to 200 messages ordered by position; 404 on unknown or cross-user access

DELETE /api/v1/chat/sessions/{session_id} - deletes the session and closes any active WebSocket connection with close code 4010; 404 on unknown or cross-user access