### PR TITLE
Add WebSocket endpoint and intent detection (issue #17)

### DIFF
--- a/app/api/v1/chat.py
+++ b/app/api/v1/chat.py
@@ -1,20 +1,142 @@
-"""Chat session REST endpoints (spec §6.4, issue #16)."""
+"""Chat session REST + WebSocket endpoints (spec §6.4, issues #16 & #17)."""
 
 import logging
+import re
+from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect, status
+from jose import JWTError
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+from app.agents.provisioning.graph import run_provisioning_agent
+from app.agents.sre.graph import run_sre_agent
 from app.api.deps import get_current_user, get_db
-from app.api.schemas.chat import MessageOut, SessionCreate, SessionDetail, SessionSummary
+from app.api.schemas.chat import (
+    MessageOut,
+    SessionCreate,
+    SessionDetail,
+    SessionSummary,
+    WSAgentResponse,
+    WSClientMessage,
+    WSError,
+    WSTyping,
+)
+from app.core.security import decode_access_token
 from app.core.ws_manager import manager
-from app.db.models import ChatMessage, ChatSession, User
+from app.db.models import ChatMessage, ChatSession, Deployment, User
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _SESSION_NOT_FOUND = "Session not found"
 _WS_SESSION_DELETED = 4010
+_WS_AUTH_FAILED = 4001
+_WS_FORBIDDEN = 4004
+
+_DEPLOY_KEYWORDS = ("provision", "deploy", "launch", "spin up", "install")
+_SRE_KEYWORDS = ("scan", "monitor", "check", "fix", "remediate", "approve")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _detect_intent(content: str) -> str:
+    text = content.lower()
+    if any(kw in text for kw in _DEPLOY_KEYWORDS):
+        return "deploy"
+    if any(kw in text for kw in _SRE_KEYWORDS):
+        return "sre"
+    return "general"
+
+
+def _extract_app_name(content: str) -> str:
+    match = re.search(
+        r"(?:deploy|provision|install|launch)\s+(?:a\s+|an\s+|my\s+)?(\S+)",
+        content.lower(),
+    )
+    if match:
+        raw = match.group(1)
+        name = re.sub(r"[^a-z0-9-]", "-", raw).strip("-")[:63]
+        if name and name[0].isalpha():
+            return name
+    return "my-app"
+
+
+def _next_position(db: Session, session_id: int) -> int:
+    result = (
+        db.query(func.max(ChatMessage.position))
+        .filter(ChatMessage.session_id == session_id)
+        .scalar()
+    )
+    return (result if result is not None else -1) + 1
+
+
+async def _dispatch(
+    *,
+    intent: str,
+    content: str,
+    user: User,
+    session_id: int,
+    db: Session,
+) -> str:
+    if intent == "deploy":
+        app_name = _extract_app_name(content)
+        try:
+            result = await run_provisioning_agent(
+                user_id=user.id,
+                namespace=user.namespace,
+                app_name=app_name,
+                requirements=content,
+                chat_session_id=session_id,
+                db=db,
+            )
+        except Exception as exc:
+            return f"Deployment failed: {exc}"
+        if result["status"] == "failed":
+            return f"Deployment failed: {result.get('error', 'unknown error')}"
+        return (
+            f"Deployed successfully — app: {app_name}, "
+            f"deployment ID: {result['deployment_id']}, status: {result['status']}"
+        )
+
+    if intent == "sre":
+        deployment = (
+            db.query(Deployment)
+            .filter(Deployment.user_id == user.id)
+            .order_by(Deployment.created_at.desc())
+            .first()
+        )
+        if deployment is None:
+            return "No deployments found. Deploy an application first before running a scan."
+        try:
+            result = await run_sre_agent(
+                user_id=user.id,
+                namespace=user.namespace,
+                deployment_id=deployment.id,
+                source="manual",
+                db=db,
+            )
+        except Exception as exc:
+            return f"SRE scan failed: {exc}"
+        if result["status"] == "no_issues":
+            return f"SRE scan complete — no issues found in deployment {deployment.id}."
+        return (
+            f"SRE scan complete — {result.get('analysis', '')}. "
+            f"Plan ID: {result.get('plan_db_id')}, status: {result['status']}"
+        )
+
+    return (
+        "I can help you deploy applications or monitor your infrastructure. "
+        "Try: 'deploy my web app' or 'scan my deployment'."
+    )
+
+
+# ---------------------------------------------------------------------------
+# REST endpoints (issue #16)
+# ---------------------------------------------------------------------------
 
 
 @router.post("/sessions", response_model=SessionSummary, status_code=status.HTTP_201_CREATED)
@@ -84,3 +206,103 @@ async def delete_session(
 
     db.delete(session)
     db.commit()
+
+
+# ---------------------------------------------------------------------------
+# WebSocket endpoint (issue #17)
+# ---------------------------------------------------------------------------
+
+
+@router.websocket("/sessions/{session_id}/ws")
+async def chat_ws(
+    session_id: int,
+    websocket: WebSocket,
+    token: str = Query(...),
+    db: Session = Depends(get_db),
+) -> None:
+    # Validate JWT from query parameter
+    try:
+        payload = decode_access_token(token)
+        user_id = int(payload.get("sub", ""))
+    except (JWTError, ValueError, TypeError):
+        await websocket.close(code=_WS_AUTH_FAILED)
+        return
+
+    user = db.get(User, user_id)
+    if user is None:
+        await websocket.close(code=_WS_AUTH_FAILED)
+        return
+
+    # Verify session ownership
+    session = db.get(ChatSession, session_id)
+    if session is None or session.user_id != user.id:
+        await websocket.close(code=_WS_FORBIDDEN)
+        return
+
+    # All checks pass — register connection and enter message loop
+    await manager.connect(user.id, session_id, websocket)
+
+    try:
+        while True:
+            try:
+                raw = await websocket.receive_json()
+                client_msg = WSClientMessage.model_validate(raw)
+            except WebSocketDisconnect:
+                raise
+            except Exception:
+                await websocket.send_json(WSError(detail="Invalid message format").model_dump())
+                continue
+
+            content = client_msg.content
+            intent = _detect_intent(content)
+            agent_name: str = "sre-agent" if intent == "sre" else "infra-agent"
+
+            # Persist user message before agent invocation
+            user_pos = _next_position(db, session_id)
+            user_msg = ChatMessage(
+                session_id=session_id, role="user", content=content, position=user_pos
+            )
+            db.add(user_msg)
+            db.commit()
+            db.refresh(user_msg)
+
+            # Typing indicator — start
+            await websocket.send_json(WSTyping(agent=agent_name, is_typing=True).model_dump())
+
+            # Route to agent
+            response_content = await _dispatch(
+                intent=intent,
+                content=content,
+                user=user,
+                session_id=session_id,
+                db=db,
+            )
+
+            # Persist agent response before sending to client
+            agent_pos = _next_position(db, session_id)
+            agent_msg = ChatMessage(
+                session_id=session_id,
+                role=agent_name,
+                content=response_content,
+                position=agent_pos,
+            )
+            db.add(agent_msg)
+            db.commit()
+            db.refresh(agent_msg)
+
+            # Update session timestamp
+            session.updated_at = datetime.now(timezone.utc)
+            db.commit()
+
+            # Completion indicator then response
+            await websocket.send_json(WSTyping(agent=agent_name, is_typing=False).model_dump())
+            await websocket.send_json(
+                WSAgentResponse(message=MessageOut.model_validate(agent_msg)).model_dump(
+                    mode="json"
+                )
+            )
+
+    except WebSocketDisconnect:
+        pass
+    finally:
+        await manager.disconnect(user.id, session_id)

--- a/tests/test_chat_ws.py
+++ b/tests/test_chat_ws.py
@@ -1,0 +1,353 @@
+"""Tests for the chat WebSocket endpoint (issue #17)."""
+
+from typing import Any
+
+import pytest
+from fastapi import WebSocketDisconnect
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.security import hash_password
+from app.db.models import ChatMessage, ChatSession, Deployment, User
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_session(db_session: Session, user_id: int, title: str = "Test") -> ChatSession:
+    session = ChatSession(user_id=user_id, title=title)
+    db_session.add(session)
+    db_session.commit()
+    db_session.refresh(session)
+    return session
+
+
+def _seed_deployment(db_session: Session, user_id: int) -> Deployment:
+    deployment = Deployment(
+        user_id=user_id,
+        app_name="web",
+        desired_state_yaml="",
+        status="deployed",
+    )
+    db_session.add(deployment)
+    db_session.commit()
+    db_session.refresh(deployment)
+    return deployment
+
+
+def _seed_other_user(db_session: Session) -> User:
+    other = User(
+        email="other@example.com",
+        hashed_password=hash_password("pw"),
+        namespace="user-other",
+    )
+    db_session.add(other)
+    db_session.commit()
+    db_session.refresh(other)
+    return other
+
+
+@pytest.fixture
+def auth_token(auth_headers: dict[str, str]) -> str:
+    return auth_headers["Authorization"].removeprefix("Bearer ")
+
+
+def _ws_url(session_id: int, token: str) -> str:
+    return f"/api/v1/chat/sessions/{session_id}/ws?token={token}"
+
+
+# ---------------------------------------------------------------------------
+# Authentication / authorisation rejection
+# ---------------------------------------------------------------------------
+
+
+def test_ws_invalid_token_closes_4001(client: TestClient) -> None:
+    try:
+        with client.websocket_connect("/api/v1/chat/sessions/1/ws?token=bad-token") as ws:
+            ws.receive_json()
+        pytest.fail("Expected WebSocketDisconnect")
+    except WebSocketDisconnect as exc:
+        assert exc.code == 4001
+
+
+def test_ws_unknown_session_closes_4004(
+    client: TestClient,
+    auth_token: str,
+) -> None:
+    try:
+        with client.websocket_connect(_ws_url(99999, auth_token)) as ws:
+            ws.receive_json()
+        pytest.fail("Expected WebSocketDisconnect")
+    except WebSocketDisconnect as exc:
+        assert exc.code == 4004
+
+
+def test_ws_other_user_session_closes_4004(
+    client: TestClient,
+    auth_token: str,
+    db_session: Session,
+) -> None:
+    other = _seed_other_user(db_session)
+    session = _seed_session(db_session, other.id)
+
+    try:
+        with client.websocket_connect(_ws_url(session.id, auth_token)) as ws:
+            ws.receive_json()
+        pytest.fail("Expected WebSocketDisconnect")
+    except WebSocketDisconnect as exc:
+        assert exc.code == 4004
+
+
+# ---------------------------------------------------------------------------
+# Intent detection — general (no agent call)
+# ---------------------------------------------------------------------------
+
+
+def test_ws_general_intent_response(
+    client: TestClient,
+    auth_token: str,
+    auth_headers: dict[str, str],
+    db_session: Session,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    session = _seed_session(db_session, user.id)
+
+    with client.websocket_connect(_ws_url(session.id, auth_token)) as ws:
+        ws.send_json({"type": "message", "content": "hello there"})
+
+        typing_start = ws.receive_json()
+        assert typing_start["type"] == "typing"
+        assert typing_start["agent"] == "infra-agent"
+        assert typing_start["is_typing"] is True
+
+        typing_stop = ws.receive_json()
+        assert typing_stop["type"] == "typing"
+        assert typing_stop["is_typing"] is False
+
+        response = ws.receive_json()
+        assert response["type"] == "agent_response"
+        assert "deploy" in response["message"]["content"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Intent detection — deploy
+# ---------------------------------------------------------------------------
+
+
+def test_ws_deploy_intent_routes_infra_agent(
+    client: TestClient,
+    auth_token: str,
+    auth_headers: dict[str, str],
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    session = _seed_session(db_session, user.id)
+
+    async def fake_provision(**kwargs: Any) -> dict[str, Any]:
+        return {"deployment_id": 42, "status": "deployed", "error": None}
+
+    monkeypatch.setattr("app.api.v1.chat.run_provisioning_agent", fake_provision)
+
+    with client.websocket_connect(_ws_url(session.id, auth_token)) as ws:
+        ws.send_json({"type": "message", "content": "deploy my nginx app"})
+
+        typing_start = ws.receive_json()
+        assert typing_start["agent"] == "infra-agent"
+        assert typing_start["is_typing"] is True
+
+        ws.receive_json()  # typing stop
+
+        response = ws.receive_json()
+        assert response["type"] == "agent_response"
+        assert "deployed" in response["message"]["content"].lower()
+
+
+def test_ws_deploy_failure_surfaced_in_response(
+    client: TestClient,
+    auth_token: str,
+    auth_headers: dict[str, str],
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    session = _seed_session(db_session, user.id)
+
+    async def fake_provision(**kwargs: Any) -> dict[str, Any]:
+        return {"deployment_id": None, "status": "failed", "error": "YAML invalid"}
+
+    monkeypatch.setattr("app.api.v1.chat.run_provisioning_agent", fake_provision)
+
+    with client.websocket_connect(_ws_url(session.id, auth_token)) as ws:
+        ws.send_json({"type": "message", "content": "deploy my app"})
+        ws.receive_json()  # typing start
+        ws.receive_json()  # typing stop
+        response = ws.receive_json()
+
+    assert "failed" in response["message"]["content"].lower()
+    assert "YAML invalid" in response["message"]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Intent detection — sre
+# ---------------------------------------------------------------------------
+
+
+def test_ws_sre_intent_routes_sre_agent(
+    client: TestClient,
+    auth_token: str,
+    auth_headers: dict[str, str],
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    session = _seed_session(db_session, user.id)
+    _seed_deployment(db_session, user.id)
+
+    async def fake_sre(**kwargs: Any) -> dict[str, Any]:
+        return {
+            "plan_db_id": 99,
+            "analysis": "pods crashlooping",
+            "rationale": "bad image",
+            "status": "awaiting_approval",
+        }
+
+    monkeypatch.setattr("app.api.v1.chat.run_sre_agent", fake_sre)
+
+    with client.websocket_connect(_ws_url(session.id, auth_token)) as ws:
+        ws.send_json({"type": "message", "content": "scan my deployment"})
+
+        typing_start = ws.receive_json()
+        assert typing_start["agent"] == "sre-agent"
+        assert typing_start["is_typing"] is True
+
+        ws.receive_json()  # typing stop
+
+        response = ws.receive_json()
+        assert response["type"] == "agent_response"
+        assert "pods crashlooping" in response["message"]["content"]
+
+
+def test_ws_sre_no_deployments_returns_helpful_message(
+    client: TestClient,
+    auth_token: str,
+    auth_headers: dict[str, str],
+    db_session: Session,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    session = _seed_session(db_session, user.id)
+    # No deployments seeded.
+
+    with client.websocket_connect(_ws_url(session.id, auth_token)) as ws:
+        ws.send_json({"type": "message", "content": "scan my deployment"})
+        ws.receive_json()  # typing start
+        ws.receive_json()  # typing stop
+        response = ws.receive_json()
+
+    assert "no deployment" in response["message"]["content"].lower()
+
+
+def test_ws_sre_no_issues_response(
+    client: TestClient,
+    auth_token: str,
+    auth_headers: dict[str, str],
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    session = _seed_session(db_session, user.id)
+    _seed_deployment(db_session, user.id)
+
+    async def fake_sre(**kwargs: Any) -> dict[str, Any]:
+        return {"plan_db_id": None, "analysis": None, "rationale": None, "status": "no_issues"}
+
+    monkeypatch.setattr("app.api.v1.chat.run_sre_agent", fake_sre)
+
+    with client.websocket_connect(_ws_url(session.id, auth_token)) as ws:
+        ws.send_json({"type": "message", "content": "monitor my app"})
+        ws.receive_json()
+        ws.receive_json()
+        response = ws.receive_json()
+
+    assert "no issues" in response["message"]["content"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Message persistence
+# ---------------------------------------------------------------------------
+
+
+def test_ws_user_and_agent_messages_persisted(
+    client: TestClient,
+    auth_token: str,
+    auth_headers: dict[str, str],
+    db_session: Session,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    session = _seed_session(db_session, user.id)
+
+    with client.websocket_connect(_ws_url(session.id, auth_token)) as ws:
+        ws.send_json({"type": "message", "content": "hello world"})
+        ws.receive_json()  # typing start
+        ws.receive_json()  # typing stop
+        ws.receive_json()  # agent response
+
+    db_session.expire_all()
+    messages = (
+        db_session.query(ChatMessage)
+        .filter(ChatMessage.session_id == session.id)
+        .order_by(ChatMessage.position)
+        .all()
+    )
+    assert len(messages) == 2
+    assert messages[0].role == "user"
+    assert messages[0].content == "hello world"
+    assert messages[0].position == 0
+    assert messages[1].role == "infra-agent"
+    assert messages[1].position == 1
+
+
+def test_ws_session_updated_at_refreshed(
+    client: TestClient,
+    auth_token: str,
+    auth_headers: dict[str, str],
+    db_session: Session,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    session = _seed_session(db_session, user.id)
+    original_updated_at = session.updated_at
+
+    with client.websocket_connect(_ws_url(session.id, auth_token)) as ws:
+        ws.send_json({"type": "message", "content": "hello"})
+        ws.receive_json()
+        ws.receive_json()
+        ws.receive_json()
+
+    db_session.expire_all()
+    refreshed = db_session.get(ChatSession, session.id)
+    assert refreshed is not None
+    assert refreshed.updated_at >= original_updated_at
+
+
+# ---------------------------------------------------------------------------
+# Invalid message format
+# ---------------------------------------------------------------------------
+
+
+def test_ws_invalid_message_format_returns_error(
+    client: TestClient,
+    auth_token: str,
+    auth_headers: dict[str, str],
+    db_session: Session,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    session = _seed_session(db_session, user.id)
+
+    with client.websocket_connect(_ws_url(session.id, auth_token)) as ws:
+        ws.send_json({"type": "unknown", "data": "bad"})
+        error = ws.receive_json()
+
+    assert error["type"] == "error"
+    assert "invalid" in error["detail"].lower()


### PR DESCRIPTION
Implements the chat WebSocket endpoint from issue #17.

WS /api/v1/chat/sessions/{session_id}/ws?token={jwt} - validates JWT from query param (→ close 4001 on failure), verifies session ownership (→ close 4004), then registers the connection with the WebSocket manager

Full message-processing pipeline per spec: persist user message → typing indicator (start) → detect intent → dispatch to agent → persist agent response → update session updated_at → typing indicator (stop) → send agent_response frame

Intent detection via keyword matching: "deploy" keywords route to infra-agent via run_provisioning_agent; "sre" keywords route to sre-agent via run_sre_agent against the user's most recent deployment; all other input falls back to a general infra-agent response

_extract_app_name parses a K8s-safe app name from deploy-intent messages
