### PR TITLE
Add visualization API and wire lifespan integration …

### DIFF
--- a/app/api/v1/visualize.py
+++ b/app/api/v1/visualize.py
@@ -1,0 +1,126 @@
+"""Visualization endpoint — live cluster state (spec §6.5, issue #18)."""
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user, get_db
+from app.api.schemas.visualize import (
+    ClusterInfo,
+    ContainerInfo,
+    HPAInfo,
+    NodeStatus,
+    PodCounts,
+    RemediationPlanRef,
+    ResourceInfo,
+    ServiceInfo,
+    StorageInfo,
+    TierInfo,
+    VisualizeResponse,
+)
+from app.db.models import Deployment, RemediationPlan, User
+from app.services.k8s_client import KubernetesService
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# NamespaceStatus → schema helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_cluster(data: dict[str, Any]) -> ClusterInfo:
+    nodes = data["nodes"]
+    return ClusterInfo(
+        name=str(data["name"]),
+        provider=str(data["provider"]),
+        region=str(data["region"]),
+        k8s_version=str(data["k8s_version"]),
+        nodes=NodeStatus(ready=int(nodes["ready"]), total=int(nodes["total"])),
+    )
+
+
+def _build_tier(data: dict[str, Any]) -> TierInfo:
+    service_data = data.get("service")
+    hpa_data = data.get("hpa")
+    storage_data = data.get("storage")
+    return TierInfo(
+        name=data["name"],
+        kind=data["kind"],
+        containers=[ContainerInfo(**c) for c in data.get("containers", [])],
+        pods=PodCounts(**data.get("pods", {})),
+        resources=ResourceInfo(**data.get("resources", {})),
+        service=ServiceInfo(**service_data) if service_data else None,
+        hpa=HPAInfo(**hpa_data) if hpa_data else None,
+        storage=StorageInfo(**storage_data) if storage_data else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{deployment_id}", response_model=VisualizeResponse)
+def visualize(
+    deployment_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> VisualizeResponse:
+    """Return live cluster state for a user-owned deployment.
+
+    Falls back to DB-only fields (cluster=null, tiers=[]) with an error
+    message when Kubernetes is unreachable (spec §6.5).
+    """
+    deployment = db.get(Deployment, deployment_id)
+    if deployment is None or deployment.user_id != user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Deployment not found")
+
+    plans = (
+        db.query(RemediationPlan)
+        .filter(RemediationPlan.deployment_id == deployment_id)
+        .order_by(RemediationPlan.created_at)
+        .all()
+    )
+    plan_refs = [
+        RemediationPlanRef(
+            id=p.id,
+            analysis=p.analysis,
+            approved=p.approved,
+            applied=p.applied,
+            source=p.source,
+            created_at=p.created_at,
+        )
+        for p in plans
+    ]
+
+    base: dict[str, Any] = dict(
+        deployment_id=deployment.id,
+        app_name=deployment.app_name,
+        status=deployment.status,
+        namespace=user.namespace,
+        created_at=deployment.created_at,
+        updated_at=deployment.updated_at,
+        traffic=None,
+        remediation_plans=plan_refs,
+    )
+
+    try:
+        k8s = KubernetesService.get_instance()
+        ns_status = k8s.get_namespace_status(user.namespace)
+        return VisualizeResponse(
+            cluster=_build_cluster(ns_status["cluster"]),
+            tiers=[_build_tier(t) for t in ns_status.get("tiers", [])],
+            **base,
+        )
+    except Exception as exc:
+        logger.warning("K8s unavailable for visualize(%s): %s", deployment_id, exc)
+        return VisualizeResponse(
+            cluster=None,
+            tiers=[],
+            error=f"Kubernetes unavailable: {exc}",
+            **base,
+        )

--- a/app/api/v1/visualize.py
+++ b/app/api/v1/visualize.py
@@ -1,7 +1,7 @@
 """Visualization endpoint — live cluster state (spec §6.5, issue #18)."""
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
@@ -113,7 +113,7 @@ def visualize(
         ns_status = k8s.get_namespace_status(user.namespace)
         return VisualizeResponse(
             cluster=_build_cluster(ns_status["cluster"]),
-            tiers=[_build_tier(t) for t in ns_status.get("tiers", [])],
+            tiers=[_build_tier(cast(dict[str, Any], t)) for t in ns_status.get("tiers", [])],
             **base,
         )
     except Exception as exc:

--- a/app/core/ws_manager.py
+++ b/app/core/ws_manager.py
@@ -115,5 +115,18 @@ class ConnectionManager:
                     exc,
                 )
 
+    async def close_all(self, code: int = 1001) -> None:
+        """Close every active WebSocket connection and clear the registry."""
+        async with self._lock:
+            all_sockets = [
+                ws for sessions in self.active_connections.values() for ws in sessions.values()
+            ]
+            self.active_connections.clear()
+        for ws in all_sockets:
+            try:
+                await ws.close(code=code)
+            except Exception as exc:
+                logger.debug("close_all close failed: %s", exc)
+
 
 manager = ConnectionManager()

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -5,10 +6,13 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api.v1 import auth, chat, deploy, monitor
+from app.api.v1 import auth, chat, deploy, monitor, visualize
 from app.core.logging_config import configure_logging
+from app.core.ws_manager import manager
 from app.db.base import Base
 from app.db.session import engine
+from app.services.k8s_client import KubernetesService
+from app.services.sre_background import sre_background_loop
 
 configure_logging()
 
@@ -21,15 +25,24 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     Base.metadata.create_all(bind=engine)
 
-    # TODO(#18): instantiate KubernetesService.get_instance() (warn on failure, do not crash)
-    # TODO(#18): bg_task = asyncio.create_task(sre_background_loop())
+    try:
+        KubernetesService.get_instance()
+    except Exception as exc:
+        logger.warning("Kubernetes client unavailable at startup: %s", exc)
+
+    bg_task = asyncio.create_task(sre_background_loop())
 
     yield
 
     logger.info("InfraPilot backend shutting down")
 
-    # TODO(#18): cancel and await bg_task
-    # TODO(#18): close all WebSocket connections via manager
+    bg_task.cancel()
+    try:
+        await bg_task
+    except asyncio.CancelledError:
+        pass
+
+    await manager.close_all()
 
     engine.dispose()
 
@@ -48,10 +61,7 @@ app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
 app.include_router(chat.router, prefix="/api/v1/chat", tags=["chat"])
 app.include_router(deploy.router, prefix="/api/v1/deploy", tags=["deploy"])
 app.include_router(monitor.router, prefix="/api/v1/monitor", tags=["monitor"])
-
-# TODO(#18): wire remaining routers once they exist
-# from app.api.v1 import visualize
-# app.include_router(visualize.router,  prefix="/api/v1/visualize",  tags=["visualize"])
+app.include_router(visualize.router, prefix="/api/v1/visualize", tags=["visualize"])
 
 
 @app.get("/health")

--- a/tests/test_visualize_rest.py
+++ b/tests/test_visualize_rest.py
@@ -1,0 +1,303 @@
+"""Tests for the visualization endpoint (issue #18)."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+import app.services.k8s_client as k8s_client_module
+from app.core.security import hash_password
+from app.db.models import Deployment, RemediationPlan, User
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NAMESPACE_STATUS: dict[str, Any] = {
+    "cluster": {
+        "name": "minikube",
+        "provider": "unknown",
+        "region": "unknown",
+        "k8s_version": "v1.28.0",
+        "nodes": {"ready": 1, "total": 1},
+    },
+    "tiers": [
+        {
+            "name": "web",
+            "kind": "Deployment",
+            "containers": [{"name": "web", "image": "nginx:latest"}],
+            "pods": {"running": 1, "pending": 0, "failed": 0, "total": 1},
+            "resources": {
+                "cpu_usage_percent": None,
+                "memory_usage_percent": None,
+                "cpu_requests": "100m",
+                "memory_requests": "128Mi",
+            },
+            "service": {"type": "ClusterIP", "port": 80},
+            "hpa": None,
+            "storage": None,
+        }
+    ],
+}
+
+
+def _seed_deployment(db_session: Session, user_id: int, **fields: Any) -> Deployment:
+    deployment = Deployment(
+        user_id=user_id,
+        app_name=fields.get("app_name", "web"),
+        desired_state_yaml=fields.get("desired_state_yaml", ""),
+        status=fields.get("status", "deployed"),
+    )
+    db_session.add(deployment)
+    db_session.commit()
+    db_session.refresh(deployment)
+    return deployment
+
+
+def _seed_plan(
+    db_session: Session,
+    deployment_id: int,
+    source: str = "manual",
+    approved: bool = False,
+    applied: bool = False,
+) -> RemediationPlan:
+    plan = RemediationPlan(
+        deployment_id=deployment_id,
+        event_summary="[]",
+        analysis="pods failing",
+        plan_json='{"actions": []}',
+        rationale="fix it",
+        approved=approved,
+        applied=applied,
+        source=source,
+    )
+    db_session.add(plan)
+    db_session.commit()
+    db_session.refresh(plan)
+    return plan
+
+
+def _seed_other_user(db_session: Session) -> User:
+    other = User(
+        email="other@example.com",
+        hashed_password=hash_password("pw"),
+        namespace="user-other",
+    )
+    db_session.add(other)
+    db_session.commit()
+    db_session.refresh(other)
+    return other
+
+
+def _mock_k8s(monkeypatch: pytest.MonkeyPatch, ns_status: dict[str, Any]) -> MagicMock:
+    mock = MagicMock()
+    mock.get_namespace_status.return_value = ns_status
+    monkeypatch.setattr(
+        k8s_client_module.KubernetesService,
+        "get_instance",
+        classmethod(lambda cls: mock),
+    )
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Happy path — K8s available
+# ---------------------------------------------------------------------------
+
+
+def test_visualize_returns_cluster_and_tiers(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    deployment = _seed_deployment(db_session, user.id)
+    _mock_k8s(monkeypatch, _NAMESPACE_STATUS)
+
+    resp = client.get(f"/api/v1/visualize/{deployment.id}", headers=auth_headers)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["deployment_id"] == deployment.id
+    assert body["app_name"] == "web"
+    assert body["status"] == "deployed"
+    assert body["cluster"]["name"] == "minikube"
+    assert body["cluster"]["nodes"] == {"ready": 1, "total": 1}
+    assert len(body["tiers"]) == 1
+    tier = body["tiers"][0]
+    assert tier["name"] == "web"
+    assert tier["kind"] == "Deployment"
+    assert tier["containers"] == [{"name": "web", "image": "nginx:latest"}]
+    assert tier["pods"]["running"] == 1
+    assert tier["service"] == {"type": "ClusterIP", "port": 80}
+    assert tier["hpa"] is None
+    assert tier["storage"] is None
+    assert body["error"] is None
+
+
+def test_visualize_traffic_always_null(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    deployment = _seed_deployment(db_session, user.id)
+    _mock_k8s(monkeypatch, _NAMESPACE_STATUS)
+
+    resp = client.get(f"/api/v1/visualize/{deployment.id}", headers=auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["traffic"] is None
+
+
+# ---------------------------------------------------------------------------
+# K8s unavailable — fallback response
+# ---------------------------------------------------------------------------
+
+
+def test_visualize_k8s_unavailable_returns_fallback(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    deployment = _seed_deployment(db_session, user.id)
+
+    mock = MagicMock()
+    mock.get_namespace_status.side_effect = Exception("connection refused")
+    monkeypatch.setattr(
+        k8s_client_module.KubernetesService,
+        "get_instance",
+        classmethod(lambda cls: mock),
+    )
+
+    resp = client.get(f"/api/v1/visualize/{deployment.id}", headers=auth_headers)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["deployment_id"] == deployment.id
+    assert body["cluster"] is None
+    assert body["tiers"] == []
+    assert body["traffic"] is None
+    assert body["error"] is not None
+    assert "connection refused" in body["error"]
+
+
+def test_visualize_k8s_instance_error_returns_fallback(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    deployment = _seed_deployment(db_session, user.id)
+
+    monkeypatch.setattr(
+        k8s_client_module.KubernetesService,
+        "get_instance",
+        classmethod(lambda cls: (_ for _ in ()).throw(Exception("k8s init failed"))),
+    )
+
+    resp = client.get(f"/api/v1/visualize/{deployment.id}", headers=auth_headers)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["cluster"] is None
+    assert body["error"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Remediation plans
+# ---------------------------------------------------------------------------
+
+
+def test_visualize_includes_all_plan_sources(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    deployment = _seed_deployment(db_session, user.id)
+    manual_plan = _seed_plan(db_session, deployment.id, source="manual")
+    bg_plan = _seed_plan(db_session, deployment.id, source="background")
+    _mock_k8s(monkeypatch, _NAMESPACE_STATUS)
+
+    resp = client.get(f"/api/v1/visualize/{deployment.id}", headers=auth_headers)
+
+    assert resp.status_code == 200
+    plans = resp.json()["remediation_plans"]
+    assert len(plans) == 2
+    sources = {p["source"] for p in plans}
+    assert sources == {"manual", "background"}
+    ids = [p["id"] for p in plans]
+    assert manual_plan.id in ids and bg_plan.id in ids
+
+
+def test_visualize_plans_ordered_by_created_at(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    deployment = _seed_deployment(db_session, user.id)
+    first = _seed_plan(db_session, deployment.id, source="manual")
+    second = _seed_plan(db_session, deployment.id, source="background")
+    _mock_k8s(monkeypatch, _NAMESPACE_STATUS)
+
+    resp = client.get(f"/api/v1/visualize/{deployment.id}", headers=auth_headers)
+
+    plans = resp.json()["remediation_plans"]
+    assert [p["id"] for p in plans] == [first.id, second.id]
+
+
+def test_visualize_no_plans_returns_empty_list(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = db_session.query(User).filter(User.email == "test@example.com").one()
+    deployment = _seed_deployment(db_session, user.id)
+    _mock_k8s(monkeypatch, _NAMESPACE_STATUS)
+
+    resp = client.get(f"/api/v1/visualize/{deployment.id}", headers=auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["remediation_plans"] == []
+
+
+# ---------------------------------------------------------------------------
+# Ownership / auth
+# ---------------------------------------------------------------------------
+
+
+def test_visualize_unknown_deployment_returns_404(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    resp = client.get("/api/v1/visualize/99999", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_visualize_other_user_deployment_returns_404(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    db_session: Session,
+) -> None:
+    other = _seed_other_user(db_session)
+    deployment = _seed_deployment(db_session, other.id)
+
+    resp = client.get(f"/api/v1/visualize/{deployment.id}", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_visualize_requires_auth(client: TestClient) -> None:
+    resp = client.get("/api/v1/visualize/1")
+    assert resp.status_code == 401


### PR DESCRIPTION
- Adds GET /api/v1/visualize/{deployment_id} returning live cluster state (pods, services, HPAs, PVCs) plus all remediation plans for the deployment

- Falls back gracefully when Kubernetes is unreachable : returns cluster=null, tiers=[] with an error field instead of a 5xx

- Wires the main.py lifespan: K8s client init (warn-on-fail), SRE background loop start/cancel, manager.close_all() on shutdown

- Adds close_all() to ConnectionManager for clean shutdown